### PR TITLE
Increase PHP memory limit to 384M

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -48,6 +48,10 @@ web:
             scripts: true
             allow: true
 
+variables:
+  php:
+    memory_limit: 384M
+
 hooks:
   deploy: |
     if [ "${PLATFORM_BRANCH}" = "master" ]; then


### PR DESCRIPTION
Used to be the default 256M.

Some users had memory problems previewing the front page.

See DAKU-4.