### PR TITLE
Increase persistent disk usage

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -29,7 +29,7 @@ relationships:
     database: "mysqldb:mysql"
 
 # The size of the persistent disk of the application (in MB).
-disk: 2048
+disk: 2560
 
 # The mounts that will be performed when the package is deployed.
 mounts:


### PR DESCRIPTION
We are currently using ~82% of the persistent disk.

The persistent disk is currently allocated 2048 MiB and the database is allocated 2048 MiB. The project has 5 GiB in total.

Increase the persistent disk by 512 MiB to get away with the "less 20% persistent disk" warning.